### PR TITLE
[fix] 리액션 관계테이블 변경

### DIFF
--- a/server/src/entities/comment-reaction.entity.ts
+++ b/server/src/entities/comment-reaction.entity.ts
@@ -34,7 +34,8 @@ export class CommentReaction extends BaseEntity {
   })
   comment: Comment;
 
-  @OneToOne(() => User)
-  @JoinColumn()
+  @ManyToOne(() => User, (user) => user.commentReactions, {
+    onDelete: 'CASCADE',
+  })
   user: User;
 }

--- a/server/src/entities/recipe-reaction.entity.ts
+++ b/server/src/entities/recipe-reaction.entity.ts
@@ -34,7 +34,8 @@ export class RecipeReaction extends BaseEntity {
   })
   recipe: Recipe;
 
-  @OneToOne(() => User)
-  @JoinColumn()
+  @ManyToOne(() => User, (user) => user.recipeReactions, {
+    onDelete: 'CASCADE',
+  })
   user: User;
 }

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -56,11 +56,11 @@ export class User extends BaseEntity {
   @OneToMany(() => Comment, (comment) => comment.user)
   comments: Comment[];
 
-  @OneToOne(() => RecipeReaction)
-  recipeReaction: RecipeReaction;
+  @OneToMany(() => RecipeReaction, (recipeReaction) => recipeReaction.user)
+  recipeReactions: RecipeReaction[];
 
-  @OneToOne(() => CommentReaction)
-  commentReaction: CommentReaction;
+  @OneToMany(() => CommentReaction, (commentReaction) => commentReaction.user)
+  commentReactions: CommentReaction[];
 
   @OneToMany(() => Bookmark, (bookmark) => bookmark.user, { eager: true })
   bookmarks: Bookmark[];


### PR DESCRIPTION
comment_reaction 과 uesr
recipe_reaction 과  user 관계 형성이 1:1로 지정되어있었는데,
1:N 관계로 수정해주었습니다

한명의 유저는 여러 코멘트 및 레시피에 여러개의 리액션을 할수있기 때문입니다.