### PR TITLE
[fix] checkMyInfo 비밀번호 확인 에러

### DIFF
--- a/client/src/pages/MyOrUserPage/MyPage.tsx
+++ b/client/src/pages/MyOrUserPage/MyPage.tsx
@@ -197,7 +197,7 @@ const MyPage = () => {
       const data = await axios.post(
         `${process.env.REACT_APP_SERVER_URL}/checkMyInfo?tokenType=${tokenType}`,
         {
-          password: password,
+          newPassword: password,
         },
         {
           withCredentials: true,
@@ -238,7 +238,7 @@ const MyPage = () => {
       const data = await axios.post(
         `${process.env.REACT_APP_SERVER_URL}/checkMyInfo?tokenType=${tokenType}`,
         {
-          password: passwordWithDraw,
+          newPassword: passwordWithDraw,
         },
         {
           withCredentials: true,

--- a/server/src/me/me.service.ts
+++ b/server/src/me/me.service.ts
@@ -224,11 +224,17 @@ export class MeService {
     user: User,
     checkInfoUserDto: CheckInfoUserReqDto,
   ): Promise<CheckInfoUserResDto> {
+    const { email } = user;
+    const { newPassword } = checkInfoUserDto;
     try {
-      const { newPassword } = checkInfoUserDto;
+      const oldUser = await this.usersRepository.findOne({
+        email,
+        password: newPassword,
+      });
+      const user = await this.usersRepository.findOne({ email });
+
       const checkPassword = await bcrypt.compare(newPassword, user.password);
-      console.log('✅', checkPassword);
-      if (checkPassword) {
+      if (checkPassword || oldUser) {
         return {
           data: null,
           statusCode: 200,


### PR DESCRIPTION
[fix] checkMyInfo 비밀번호 확인 에러 수정
기존 로그인 방식과 동일하게 예전 이메일 가입자(oldUser)와 신규가입자 (bcrypt 적용) 나눠서 로직 작성했습니다.